### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'encoding' fro…

### DIFF
--- a/ultralytics/utils/__init__.py
+++ b/ultralytics/utils/__init__.py
@@ -236,7 +236,7 @@ def set_logging(name=LOGGING_NAME, verbose=True):
 
     # Configure the console (stdout) encoding to UTF-8
     formatter = logging.Formatter("%(message)s")  # Default formatter
-    if WINDOWS and sys.stdout.encoding != "utf-8":
+    if WINDOWS and sys.stdout and sys.stdout.encoding != "utf-8":
         try:
             if hasattr(sys.stdout, "reconfigure"):
                 sys.stdout.reconfigure(encoding="utf-8")


### PR DESCRIPTION
…m ultralytics\utils_init_.py

it will throw error when there is no stdout console , File "ultralytics\utils_init_.py", line 238, in set_logging AttributeError: 'NoneType' object has no attribute 'encoding'

I have read the CLA Document and I sign the CLA